### PR TITLE
Make login work with express sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,4 @@ nodemon server.mjs
 
 # Step 3. Use frontend
 
-
-Open `lovalhost:5000` in the browser.
+Open `localhost:5000` in the browser.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# About
+# Step 1. Build the client (no hot-reload yet)
 
 ```sh
-npm install
+npm run build
 ```
 
-## Backend
+# Step 2. Start server
 
 ```sh
 nodemon server.mjs
@@ -12,10 +12,7 @@ nodemon server.mjs
 
 **Note**: starts the backend server on port 5000
 
-## Frontend
+# Step 3. Use frontend
 
-```sh
-npm start
-```
 
-**Note**: starts the frontend web server on port 3000 and proxies requests like `/login` to http://localhost:5000
+Open `lovalhost:5000` in the browser.

--- a/server.mjs
+++ b/server.mjs
@@ -14,9 +14,10 @@ app.use(express.json())
 app.use(session({
   secret: 'keyboard cat',
   resave: false,
+  // https://github.com/expressjs/session#saveuninitialized
   saveUninitialized: false,
-  // for local servers comment out:
-  // cookie: { secure: true }
+  // https://github.com/expressjs/session/issues/837
+  cookie: { secure: false }
 }))
 app.use(express.static(path.join(__dirname, "build")));
 console.log(path.join(__dirname, "build"))
@@ -46,6 +47,14 @@ app.post('/login', (req, res) => {
     } else {
         res.status(401).send('Wrong username or password')
     }
+})
+
+app.delete('/logout', (req, res) => {
+    if (req.session) {
+        req.session.destroy()
+        res.status(200).send('ok')
+    }
+    res.end()
 })
 
 app.listen(5000, () => console.log('http://localhost:5000'))

--- a/server.mjs
+++ b/server.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-var app = express()
+const app = express()
 
 app.use(express.json())
 app.use(session({
@@ -19,13 +19,13 @@ app.use(session({
   // https://github.com/expressjs/session/issues/837
   cookie: { secure: false }
 }))
+
+// HTML, JS, JPG, etc file requests will be served using
+// the build folder. 
 app.use(express.static(path.join(__dirname, "build")));
-console.log(path.join(__dirname, "build"))
 
 // The landing page will be served by the static middleware.
-// app.get('/', (req, res) => { 
-
-// })
+// app.get('/', (req, res) => { })
 
 app.get('/no-need-for-login', (req, res) => {
     res.send('<h1>Everyone can see this</h1>')
@@ -42,8 +42,8 @@ app.get('/login-needed', (req, res) => {
 app.post('/login', (req, res) => {
     const { username, password } = req.body
     if (username === 'joe' && password === 'joe') {
+        // This session change triggers the session creation
         req.session.username = username
-        console.log(req.session)
         res.status(200).send('ok')
     } else {
         res.status(401).send('Wrong username or password')

--- a/server.mjs
+++ b/server.mjs
@@ -3,12 +3,12 @@ import session from 'express-session'
 import path from 'path'
 import { fileURLToPath } from 'url';
 
+// In my current node version (14.18.1) __dirname is not yet available.
+// I'll upgrade it soon.
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 var app = express()
-
-//app.set('trust proxy', 1) // trust first proxy
 
 app.use(express.json())
 app.use(session({
@@ -22,9 +22,10 @@ app.use(session({
 app.use(express.static(path.join(__dirname, "build")));
 console.log(path.join(__dirname, "build"))
 
-app.get('/', (req, res) => { 
+// The landing page will be served by the static middleware.
+// app.get('/', (req, res) => { 
 
-})
+// })
 
 app.get('/no-need-for-login', (req, res) => {
     res.send('<h1>Everyone can see this</h1>')

--- a/server.mjs
+++ b/server.mjs
@@ -1,5 +1,10 @@
 import express from 'express'
 import session from 'express-session'
+import path from 'path'
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 var app = express()
 
@@ -9,9 +14,16 @@ app.use(express.json())
 app.use(session({
   secret: 'keyboard cat',
   resave: false,
-  saveUninitialized: true,
-  cookie: { secure: true }
+  saveUninitialized: false,
+  // for local servers comment out:
+  // cookie: { secure: true }
 }))
+app.use(express.static(path.join(__dirname, "build")));
+console.log(path.join(__dirname, "build"))
+
+app.get('/', (req, res) => { 
+
+})
 
 app.get('/no-need-for-login', (req, res) => {
     res.send('<h1>Everyone can see this</h1>')
@@ -19,18 +31,20 @@ app.get('/no-need-for-login', (req, res) => {
 
 app.get('/login-needed', (req, res) => {
     if (!req.session.username) {
-        res.send(401)
+        res.status(401).send('Login needed')
+    } else {
+        res.send(`<h1>Only logged in user (${req.session.username}) can see this</h1>`)
     }
-    res.send(`<h1>Only logged in user (${username}) can see this</h1>`)
 })
 
 app.post('/login', (req, res) => {
     const { username, password } = req.body
     if (username === 'joe' && password === 'joe') {
         req.session.username = username
-        res.send(200)
+        console.log(req.session)
+        res.status(200).send('ok')
     } else {
-        res.send(401)
+        res.status(401).send('Wrong username or password')
     }
 })
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,10 @@
 import Login from "./components/Login"
+import Nav from "./components/Nav"
+
 
 function App() {
-  return <Login />
+  return <div><Nav /><Login /></div>
+  
 }
 
 export default App;

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -1,6 +1,6 @@
 import { useState } from "react"
 
-function Login() {
+export default function Login() {
     const [username, setUsername] = useState('joe')
     const [password, setPassword] = useState('joe')
 
@@ -19,7 +19,26 @@ function Login() {
         if ( msg === 'ok') {
             alert('Successful login!')
         } else if ( msg == 'Wrong username or password') {
-            alert('Unsuccessful login!😕')
+            alert('Unsuccessful login! 😕')
+        }
+        
+    }
+
+    async function handleLogout() {
+        const resp = await fetch('/logout', {
+            method: 'DELETE',
+            // headers: {
+            //     'Content-Type': 'application/json'
+            // },
+            // body: JSON.stringify({
+            //     username,
+            //     password,
+            })
+        const msg = await resp.text()
+        if ( msg === 'ok') {
+            alert('Successful logout!')
+        } else {
+            alert('Cannot log out! 😕')
         }
         
     }
@@ -30,7 +49,6 @@ function Login() {
         Password: <input onChange={(e) => setPassword(e.target.value)} value={password} />
         <br />
         <button onClick={handleLogin}>Login</button>
+        <button onClick={handleLogout}>Logout</button>
     </>
 }
-
-export default Login

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -5,7 +5,7 @@ function Login() {
     const [password, setPassword] = useState('joe')
 
     async function handleLogin() {
-        await fetch('/login', {
+        const resp = await fetch('/login', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
@@ -15,7 +15,13 @@ function Login() {
                 password,
             })
         })
-        alert('Successful login!')
+        const msg = await resp.text()
+        if ( msg === 'ok') {
+            alert('Successful login!')
+        } else if ( msg == 'Wrong username or password') {
+            alert('Unsuccessful login!😕')
+        }
+        
     }
 
     return <>

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -1,0 +1,9 @@
+export default function Nav() {
+
+    return (
+      <div style={{display: 'flex', flexDirection: 'row', padding: '12px'}}>
+        <a style={{padding:'4px'}} href='/no-need-for-login'>Public page</a>
+        <a style={{padding:'4px'}}  href='/login-needed'>Secret page</a>
+      </div>
+    )
+}


### PR DESCRIPTION
Summary (I'll also comment inline)

- Decided to serve the landing page with express. For me it's easier to understand the possible redirects. (Not yet implemented.) But the price of this is that we need to rebuild the frontend on changes. For the workshop it's not necessary.
- Two modifications were needed in the session middleware to make it work.
    - In local development mode (without a HTTPS setup) we need `cookie: { secure: false }`, since express doesn't send cookies on an unsecured "channel" if it's set to `true`.
    - `saveUninitialized: false`: I'm not sure I understand it, but by trial and error I needed this setting for the session middleware to create the session on the backend when we modify `session.username`.